### PR TITLE
Add 2 methods to RoutingModel class

### DIFF
--- a/ext/or-tools/ext.cpp
+++ b/ext/or-tools/ext.cpp
@@ -833,6 +833,15 @@ void Init_ext()
         self.AddDimensionWithVehicleCapacity(evaluator_index, slack_max, vehicle_capacities, fix_start_cumul_to_zero, name);
       })
     .define_method(
+      "add_dimension_with_vehicle_transits",
+      *[](RoutingModel& self, Array rb_indices, int64 slack_max, int64 capacity, bool fix_start_cumul_to_zero, const std::string& name) {
+        std::vector<int> evaluator_indices;
+        for (std::size_t i = 0; i < rb_indices.size(); ++i) {
+          evaluator_indices.push_back(from_ruby<int>(rb_indices[i]));
+        }
+        self.AddDimensionWithVehicleTransits(evaluator_indices, slack_max, capacity, fix_start_cumul_to_zero, name);
+      })
+    .define_method(
       "add_disjunction",
       *[](RoutingModel& self, Array rb_indices, int64 penalty) {
         std::vector<int64> indices;

--- a/ext/or-tools/ext.cpp
+++ b/ext/or-tools/ext.cpp
@@ -820,15 +820,15 @@ void Init_ext()
         auto status = self.status();
 
         if (status == RoutingModel::ROUTING_NOT_SOLVED ) {
-          return Symbol("routing_not_solved");
+          return Symbol("not_solved");
         } else if (status == RoutingModel::ROUTING_SUCCESS ) {
-          return Symbol("routing_success");
+          return Symbol("success");
         } else if (status == RoutingModel::ROUTING_FAIL ) {
-          return Symbol("routing_fail");
+          return Symbol("fail");
         } else if (status == RoutingModel::ROUTING_FAIL_TIMEOUT ) {
-          return Symbol("routing_fail_timeout");
+          return Symbol("fail_timeout");
         } else if (status == RoutingModel::ROUTING_INVALID ) {
-          return Symbol("routing_invalid");
+          return Symbol("invalid");
         } else {
           throw std::runtime_error("Unknown solver status");
         }

--- a/ext/or-tools/ext.cpp
+++ b/ext/or-tools/ext.cpp
@@ -828,7 +828,7 @@ void Init_ext()
         } else if (status == RoutingModel::ROUTING_FAIL_TIMEOUT ) {
           return Symbol("routing_fail_timeout");
         } else if (status == RoutingModel::ROUTING_INVALID ) {
-          return Symbol("unknown");
+          return Symbol("routing_invalid");
         } else {
           throw std::runtime_error("Unknown solver status");
         }

--- a/ext/or-tools/ext.cpp
+++ b/ext/or-tools/ext.cpp
@@ -816,6 +816,23 @@ void Init_ext()
       })
     .define_method("depot", &RoutingModel::GetDepot)
     .define_method("size", &RoutingModel::Size)
+    .define_method("status", *[](RoutingModel& self) {
+        auto status = self.status();
+
+        if (status == RoutingModel::ROUTING_NOT_SOLVED ) {
+          return Symbol("routing_not_solved");
+        } else if (status == RoutingModel::ROUTING_SUCCESS ) {
+          return Symbol("routing_success");
+        } else if (status == RoutingModel::ROUTING_FAIL ) {
+          return Symbol("routing_fail");
+        } else if (status == RoutingModel::ROUTING_FAIL_TIMEOUT ) {
+          return Symbol("routing_fail_timeout");
+        } else if (status == RoutingModel::ROUTING_INVALID ) {
+          return Symbol("unknown");
+        } else {
+          throw std::runtime_error("Unknown solver status");
+        }
+      })
     .define_method("vehicle_var", &RoutingModel::VehicleVar)
     .define_method("set_arc_cost_evaluator_of_all_vehicles", &RoutingModel::SetArcCostEvaluatorOfAllVehicles)
     .define_method("set_arc_cost_evaluator_of_vehicle", &RoutingModel::SetArcCostEvaluatorOfVehicle)

--- a/test/routing_test.rb
+++ b/test/routing_test.rb
@@ -52,7 +52,7 @@ class RoutingTest < Minitest::Test
 
     assert_equal [0, 7, 2, 3, 4, 12, 6, 8, 1, 11, 10, 5, 9, 0], route
     assert_equal 7293, route_distance
-    assert_equal :routing_success, status
+    assert_equal :success, status
   end
 
   # https://developers.google.com/optimization/routing/vrp
@@ -757,7 +757,7 @@ class RoutingTest < Minitest::Test
     manager = ORTools::RoutingIndexManager.new(data[:distance_matrix].size, data[:num_vehicles], data[:depot])
     routing = ORTools::RoutingModel.new(manager)
 
-    transit_callback_indecies = []
+    transit_callback_indices = []
     data[:num_vehicles].times do |vehicle_id|
       distance_callback = lambda do |from_index, to_index|
         from_node = manager.index_to_node(from_index)
@@ -765,12 +765,12 @@ class RoutingTest < Minitest::Test
         data[:distance_matrix][from_node][to_node]*data[:vehicle_speeds][vehicle_id]
       end
       transit_callback_index = routing.register_transit_callback(distance_callback)
-      transit_callback_indecies << transit_callback_index
-      routing.set_arc_cost_evaluator_of_vehicle(transit_callback_indecies[vehicle_id], vehicle_id)
+      transit_callback_indices << transit_callback_index
+      routing.set_arc_cost_evaluator_of_vehicle(transit_callback_indices[vehicle_id], vehicle_id)
     end
 
     dimension_name = "Running Time"
-    routing.add_dimension_with_vehicle_transits(transit_callback_indecies, 0, 300000, true, dimension_name)
+    routing.add_dimension_with_vehicle_transits(transit_callback_indices, 0, 300000, true, dimension_name)
     running_time_dimension = routing.mutable_dimension(dimension_name)
     running_time_dimension.global_span_cost_coefficient = 100
     


### PR DESCRIPTION
Dear @ankane,

Thank you for making this gem.

When using it to solve Vehicle Routing Problem, I faced with 2 problems
1. Sometimes OR-tools can't solve the problem cause the parameters are not solvable. I usually get this error message `[BUG] Segmentation fault at 0x0000000000000018` when I call `solution.value(routing.next_var(index))`
So, I added RoutingModel status method to check it before call routing.next_var
https://google.github.io/or-tools/cpp_routing/classoperations__research_1_1_routing_model.html#a67a0db04d321a74b7e7fcfd3f1a3f70b

2. I also added this method add_dimension_with_vehicle_transits to solve Vehicle Routing with Different Vehicle Speed Problem 
https://google.github.io/or-tools/cpp_routing/classoperations__research_1_1_routing_model.html#a66b87fec514d648c751ad9d4df09d05b

Please review this pull request,
Thanks