### PR TITLE
Fix filename for Debian

### DIFF
--- a/ext/or-tools/vendor.rb
+++ b/ext/or-tools/vendor.rb
@@ -18,7 +18,7 @@ else
     filename = "or-tools_ubuntu-18.04_v#{version}.tar.gz"
     checksum = "0d052deb2ba4491c29e86242fb5d61d0fe14bac847c2feaa35fbeff925ea40a0"
   elsif os == "Debian" && os_version == "10"
-    filename = "or-tools_debian-10_v#{version}.tar.gz "
+    filename = "or-tools_debian-10_v#{version}.tar.gz"
     checksum = "1f2ec99181c92859ab46e68a6231babce92ded949fd1d08ee31afa4db04c43b3"
   elsif os == "CentOS" && os_version == "8"
     filename = "or-tools_centos-8_v#{version}.tar.gz"


### PR DESCRIPTION
```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'or-tools', '0.4.2'
end
```

```
/usr/local/lib/ruby/3.0.0/bundler/installer/parallel_installer.rb:197:in `handle_error': Gem::Ext::BuildError: ERROR: Failed to build gem native extension. (Bundler::InstallError)

    current directory: /usr/local/bundle/gems/or-tools-0.4.2/ext/or-tools
/usr/local/bin/ruby -I /usr/local/lib/ruby/3.0.0 -r ./siteconf20210321-22673-iox80p.rb extconf.rb
checking for -lstdc++... yes
Downloading https://github.com/google/or-tools/releases/download/v8.2/or-tools_debian-10_v8.2.8710.tar.gz ...
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/usr/local/bin/$(RUBY_BASE_NAME)
        --with-libpath
        --without-libpath
        --with-stdc++-dir
        --without-stdc++-dir
        --with-stdc++-include
        --without-stdc++-include=${stdc++-dir}/include
        --with-stdc++-lib
        --without-stdc++-lib=${stdc++-dir}/lib
        --with-stdc++lib
        --without-stdc++lib
        --with-or-tools-dir
        --without-or-tools-dir
        --with-or-tools-include
        --without-or-tools-include=${or-tools-dir}/include
        --with-or-tools-lib
        --without-or-tools-lib=${or-tools-dir}/lib
/usr/local/lib/ruby/3.0.0/uri/rfc3986_parser.rb:67:in `split': bad URI(is not URI?): "https://github.com/google/or-tools/releases/download/v8.2/or-tools_debian-10_v8.2.8710.tar.gz " (URI::InvalidURIError)
        from /usr/local/lib/ruby/3.0.0/uri/rfc3986_parser.rb:72:in `parse'
        from /usr/local/lib/ruby/3.0.0/uri/common.rb:171:in `parse'
        from /usr/local/lib/ruby/3.0.0/uri/common.rb:674:in `URI'
        from /usr/local/bundle/gems/or-tools-0.4.2/ext/or-tools/vendor.rb:45:in `download_file'
        from /usr/local/bundle/gems/or-tools-0.4.2/ext/or-tools/vendor.rb:80:in `<top (required)>'
        from extconf.rb:17:in `require_relative'
        from extconf.rb:17:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /usr/local/bundle/extensions/x86_64-linux/3.0.0/or-tools-0.4.2/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/bundle/gems/or-tools-0.4.2 for inspection.
Results logged to /usr/local/bundle/extensions/x86_64-linux/3.0.0/or-tools-0.4.2/gem_make.out

An error occurred while installing or-tools (0.4.2), and Bundler cannot continue.
Make sure that `gem install or-tools -v '0.4.2' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  or-tools
        from /usr/local/lib/ruby/3.0.0/bundler/installer/parallel_installer.rb:102:in `call'
        from /usr/local/lib/ruby/3.0.0/bundler/installer/parallel_installer.rb:78:in `call'
        from /usr/local/lib/ruby/3.0.0/bundler/installer.rb:285:in `install_in_parallel'
        from /usr/local/lib/ruby/3.0.0/bundler/installer.rb:209:in `install'
        from /usr/local/lib/ruby/3.0.0/bundler/installer.rb:91:in `block in run'
        from /usr/local/lib/ruby/3.0.0/bundler/process_lock.rb:12:in `block in lock'
        from /usr/local/lib/ruby/3.0.0/bundler/process_lock.rb:9:in `open'
        from /usr/local/lib/ruby/3.0.0/bundler/process_lock.rb:9:in `lock'
        from /usr/local/lib/ruby/3.0.0/bundler/installer.rb:72:in `run'
        from /usr/local/lib/ruby/3.0.0/bundler/installer.rb:24:in `install'
        from /usr/local/lib/ruby/3.0.0/bundler/inline.rb:62:in `block (2 levels) in gemfile'
        from /usr/local/lib/ruby/3.0.0/bundler/settings.rb:115:in `temporary'
        from /usr/local/lib/ruby/3.0.0/bundler/inline.rb:61:in `block in gemfile'
        from /usr/local/lib/ruby/3.0.0/bundler/settings.rb:115:in `temporary'
        from /usr/local/lib/ruby/3.0.0/bundler/inline.rb:54:in `gemfile'
        from foo.rb:3:in `<main>'
```